### PR TITLE
feat(cloudformation): AWS Autopilot Role with CloudFormation [ENG-45915]

### DIFF
--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,0 +1,6 @@
+---
+formatter: markdown
+
+output:
+  file: README.md
+  mode: inject

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `
 module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
     drata_external_id = "YOUR_EXTERNAL_ID"
+    # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
     # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
+    # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend is different
 }
 ```
 
@@ -25,11 +27,13 @@ The following steps will guide you on how to run this script.
 2. Replace `main` in `ref=main` with the latest version from the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases).
 3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
-5. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
-6. Back in your terminal, run terraform init to download/update the module.
-7. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
-8.  If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
-9.  If you want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+5. Add the organizational unit ids into the `organizational_unit_ids` param if you don't wish to assign the role to all sub accounts.
+6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
+7. `drata_aws_account_arn` should be set because the role needs the Drata Account ARN to work as appropriate.
+8. Back in your terminal, run terraform init to download/update the module.
+9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
+10. If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
+11. If you want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module "drata_role_cloudformation_stacksets" {
     # mgmt_account_release_tag = "1.0.0" # If it's unset the default value is 'main'
 }
 
-# as stacksets isn't able to create resources under the management account, another module is used to go forward
+# as stacksets isn't able to create resources under the management account this module is used to go forward
 module "management_account_autopilot_role" {
     source = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=main"
     role_sts_externalid = "YOUR_EXTERNAL_ID"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_drata_aws_account_arn"></a> [drata\_aws\_account\_arn](#input\_drata\_aws\_account\_arn) | Drata's AWS account ARN | `string` | `"arn:aws:iam::269135526815:root"` | no |
+| <a name="input_drata_aws_account_id"></a> [drata\_aws\_account\_id](#input\_drata\_aws\_account\_id) | Drata's AWS account ID | `string` | `"269135526815"` | no |
 | <a name="input_organizational_unit_ids"></a> [organizational\_unit\_ids](#input\_organizational\_unit\_ids) | Organizational Unit Ids to assign the role to. | `list(string)` | `null` | no |
 | <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | Drata External ID from the Drata UI. | `string` | n/a | yes |
 | <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
 # aws-cloudformation-drata-setup
+
+AWS Cloudformation terraform to create the Drata Autopilot role across a given Organization.
+
+## Example Usage
+
+The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the release page for a list of published versions. [releases page](https://github.com/drata/gcp-terraform-drata-setup/releases) for a list of published versions.
+
+Replace `YOUR_EXTERNAL_ID` with the external id that is given by the UI. i.e. `00000000-0000-0000-0000-000000000000`.
+Replace `YOUR_MANAGEMENT_ACCOUNT_ID` with the id of the management account. i.e. `012345678912`.
+
+```
+module "drata_role_stacksets" {
+    source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
+    drata_external_id = "YOUR_EXTERNAL_ID"
+    management_account_id = "YOUR_MANAGEMENT_ACCOUNT_ID"
+    # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
+    # drata_role_name = "YOUR_ROLE_NAME" # If it's unset the default value is 'DrataAutopilotRole'
+    # mgmt_account_release_tag = "1.0.0" # If it's unset the default value is 'main'
+}
+
+# as stacksets doesn't create resources in the management account, another module is used to go forward
+module "management_account_autopilot_role" {
+    source = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=main"
+    role_sts_externalid = "YOUR_EXTERNAL_ID"
+    drata_aws_account_arn = "arn:aws:iam::${"YOUR_MANAGEMENT_ACCOUNT_ID"}:root"
+    # role_name = var.role_name # If it's unset the default value is 'DrataAutopilotRole'
+}
+```
+
+## Setup
+
+The following steps will guide you on how to run this script.
+
+1. Add the code above to your terraform code
+2. Replace `main` in `ref=main` with the latest version from the releases pages.
+   1. [Cloudformation repo](https://github.com/drata/aws-cloudformation-drata-setup/releases).
+   2. [Management account repo](https://github.com/drata/terraform-aws-drata-autopilot-role/releases).
+3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
+4. Copy the Drata External ID from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
+5. Go to the AWS console, get the `Management Account Id` and replace `YOUR_MANAGEMENT_ACCOUNT_ID`.
+6. Replace `stackset_region` if the desired region is different than `us-west-2`.
+7. The role name can be customized by setting the `drata_role_name` variable. Recommend to use `DrataAutopilotRole`.
+8. `mgmt_account_release_tag` belongs to the module that creates the role in the management account, so you can point to a specific release version with this. Recommend to use `main`. 
+9. Back in your terminal, run terraform init to download/update the module.
+10. Run terraform apply and IMPORTANT review the plan output before typing yes.
+11. If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
+12. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudformation_stack_set.stack_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set_instance.instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
+| [aws_organizations_organization.organization](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_drata_external_id"></a> [drata\_external\_id](#input\_drata\_external\_id) | Retrieved ID from the Drata UI. | `string` | n/a | yes |
+| <a name="input_drata_role_name"></a> [drata\_role\_name](#input\_drata\_role\_name) | Drata role name. | `string` | `"DrataAutopilotRole"` | no |
+| <a name="input_management_account_id"></a> [management\_account\_id](#input\_management\_account\_id) | Management account id from your organization. | `string` | n/a | yes |
+| <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ The following steps will guide you on how to run this script.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
 5. Go to the AWS console, get the `Management Account Id` and replace `YOUR_MANAGEMENT_ACCOUNT_ID`.
 6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
-7. The role name can be customized by setting the `drata_role_name` variable. Recommend to use `DrataAutopilotRole`.
-8. Back in your terminal, run terraform init to download/update the module.
-9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
-10. If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
-11. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+7. Back in your terminal, run terraform init to download/update the module.
+8. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
+9.  If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
+10. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `
 module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
     role_sts_externalid = "YOUR_EXTERNAL_ID"
-    # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
+    # stackset_region = "REGION" # Uncomment if you'd like to change the default value of 'us-west-2'
     # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
     # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend of running this script is different
 }

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ AWS Cloudformation terraform script to create the Drata Autopilot role across an
 
 ## Example Usage
 
-The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the release page for a list of published versions. 
-* [CloudFormation repo](https://github.com/drata/aws-cloudformation-drata-setup/releases).
-* [Single account repo](https://github.com/drata/terraform-aws-drata-autopilot-role/releases).
+The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases) for a list of published versions.
 
 Replace `YOUR_EXTERNAL_ID` with the external id given by the UI. i.e. `00000000-0000-0000-0000-000000000000`.
 Replace `YOUR_MANAGEMENT_ACCOUNT_ID` with the AWS management account. i.e. `012345678912`.
@@ -17,16 +15,6 @@ module "drata_role_cloudformation_stacksets" {
     drata_external_id = "YOUR_EXTERNAL_ID"
     management_account_id = "YOUR_MANAGEMENT_ACCOUNT_ID"
     # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
-    # drata_role_name = "YOUR_ROLE_NAME" # If it's unset the default value is 'DrataAutopilotRole'
-    # mgmt_account_release_tag = "1.0.0" # If it's unset the default value is 'main'
-}
-
-# as stacksets isn't able to create resources under the management account this module is used to go forward
-module "management_account_autopilot_role" {
-    source = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=main"
-    role_sts_externalid = "YOUR_EXTERNAL_ID"
-    drata_aws_account_arn = "arn:aws:iam::${"YOUR_MANAGEMENT_ACCOUNT_ID"}:root"
-    # role_name = var.role_name # If it's unset the default value is 'DrataAutopilotRole'
 }
 ```
 
@@ -35,9 +23,7 @@ module "management_account_autopilot_role" {
 The following steps will guide you on how to run this script.
 
 1. Add the code above to your terraform code.
-2. Replace `main` in `ref=main` with the latest version from the release pages.
-   * [CloudFormation repo](https://github.com/drata/aws-cloudformation-drata-setup/releases).
-   * [Single account repo](https://github.com/drata/terraform-aws-drata-autopilot-role/releases).
+2. Replace `main` in `ref=main` with the latest version from the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases).
 3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
 5. Go to the AWS console, get the `Management Account Id` and replace `YOUR_MANAGEMENT_ACCOUNT_ID`.
@@ -47,6 +33,10 @@ The following steps will guide you on how to run this script.
 9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
 10. If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
 11. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+
+## Disclaimer
+
+AWS CloudFormation StackSets isn't able to create resources under the management account. If you wish to create the `DrataAutopilotRole` in the management account go to this [repo](https://github.com/drata/terraform-aws-drata-autopilot-role).
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -75,8 +65,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_drata_external_id"></a> [drata\_external\_id](#input\_drata\_external\_id) | Retrieved ID from the Drata UI. | `string` | n/a | yes |
-| <a name="input_drata_role_name"></a> [drata\_role\_name](#input\_drata\_role\_name) | Drata role name. | `string` | `"DrataAutopilotRole"` | no |
+| <a name="input_drata_external_id"></a> [drata\_external\_id](#input\_drata\_external\_id) | Drata External ID from the Drata UI. | `string` | n/a | yes |
 | <a name="input_management_account_id"></a> [management\_account\_id](#input\_management\_account\_id) | Management account id from your organization. | `string` | n/a | yes |
 | <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module "drata_role_cloudformation_stacksets" {
     role_sts_externalid = "YOUR_EXTERNAL_ID"
     # stackset_region = "REGION" # Uncomment if you'd like to change the default value of 'us-west-2'
     # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # Uncomment if you'd like to change the default behavior, which assigns the role to all sub accounts within the organization
-    # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # Uncomment if you'd like to change the default value. The default value should be sufficient for most use cases
+    # drata_aws_account_id = "XXXXXXXXXXXX" # Uncomment if you'd like to change the default value. The default value should be sufficient for most use cases
 }
 ```
 
@@ -29,7 +29,7 @@ The following steps will guide you on how to run this script.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
 5. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
 6. If you don't wish to assign the role to all sub accounts, add the organizational unit ids to `organizational_unit_ids`.
-7. `drata_aws_account_arn` shouldn't be set because unless there is a specific requirement.
+7. `drata_aws_account_id` shouldn't be set because the default value is enough for most use cases.
 8. Back in your terminal, run terraform init to download/update the module.
 9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
 10. If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_drata_external_id"></a> [drata\_external\_id](#input\_drata\_external\_id) | Drata External ID from the Drata UI. | `string` | n/a | yes |
-| <a name="input_management_account_id"></a> [management\_account\_id](#input\_management\_account\_id) | Management account id from your organization. | `string` | n/a | yes |
 | <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following steps will guide you on how to run this script.
 6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
 7. Back in your terminal, run terraform init to download/update the module.
 8. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
-9.  If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
+9.  If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
 10. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -8,13 +8,11 @@ AWS Cloudformation terraform script to create the Drata Autopilot role across an
 The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases) for a list of published versions.
 
 Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `00000000-0000-0000-0000-000000000000`.
-Replace `YOUR_MANAGEMENT_ACCOUNT_ID` with the AWS management account. i.e. `012345678912`.
 
 ```
 module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
     drata_external_id = "YOUR_EXTERNAL_ID"
-    management_account_id = "YOUR_MANAGEMENT_ACCOUNT_ID"
     # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
 }
 ```
@@ -27,12 +25,11 @@ The following steps will guide you on how to run this script.
 2. Replace `main` in `ref=main` with the latest version from the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases).
 3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
-5. Go to the AWS console, get the `Management Account Id` and replace `YOUR_MANAGEMENT_ACCOUNT_ID`.
-6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
-7. Back in your terminal, run terraform init to download/update the module.
-8. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
-9.  If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
-10. If you want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+5. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
+6. Back in your terminal, run terraform init to download/update the module.
+7. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
+8.  If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
+9.  If you want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
 
 ## Disclaimer
 
@@ -65,7 +62,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_drata_external_id"></a> [drata\_external\_id](#input\_drata\_external\_id) | Drata External ID from the Drata UI. | `string` | n/a | yes |
+| <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | Drata External ID from the Drata UI. | `string` | `null` | no |
 | <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `
 ```
 module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
-    drata_external_id = "YOUR_EXTERNAL_ID"
+    role_sts_externalid = "YOUR_EXTERNAL_ID"
     # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
     # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
     # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend of running this script is different
@@ -25,7 +25,7 @@ The following steps will guide you on how to run this script.
 
 1. Add the code above to your terraform code.
 2. Replace `main` in `ref=main` with the latest version from the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases).
-3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
+3. In your browser, open [https://app.drata.com/account-settings/connections/connection?provId=AWS_ORG_UNITS](https://app.drata.com/account-settings/connections/connection?provId=AWS_ORG_UNITS&provTypeSelected=Infrastructure&activeTab=browse&q=aws%20org&page=1).
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
 5. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
 6. If you don't wish to assign the role to all sub accounts, add the organizational unit ids to `organizational_unit_ids`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module "drata_role_cloudformation_stacksets" {
     drata_external_id = "YOUR_EXTERNAL_ID"
     # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
     # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
-    # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend is different
+    # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend of running this script is different
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following steps will guide you on how to run this script.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
 5. Add the organizational unit ids into the `organizational_unit_ids` param if you don't wish to assign the role to all sub accounts.
 6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
-7. `drata_aws_account_arn` should be set because the role needs the Drata Account ARN to work as appropriate.
+7. `drata_aws_account_arn` shouldn't be set because the role needs the Drata Account ARN to work as appropriate.
 8. Back in your terminal, run terraform init to download/update the module.
 9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
 10. If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 AWS Cloudformation terraform script to create the Drata Autopilot role across an Organizational Unit.
 ***NOTE:*** Make sure you run this script with the management account credentials.
 
+_Optionally you may create the CloudFormation StackSet directly in the console, download the [json template](https://github.com/drata/aws-cloudformation-drata-setup/drata_cloudformation_stackset_template.json) and upload it as a template resource._
+
 ## Example Usage
 
 The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases) for a list of published versions.
@@ -18,6 +20,8 @@ module "drata_role_cloudformation_stacksets" {
     # drata_aws_account_id = "XXXXXXXXXXXX" # Uncomment if you'd like to change the default value. The default value should be sufficient for most use cases
 }
 ```
+
+
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `
 module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
     drata_external_id = "YOUR_EXTERNAL_ID"
-    # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
     # stackset_region = "REGION" # If it's unset the default value is 'us-west-2'
+    # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
     # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend of running this script is different
 }
 ```
@@ -27,9 +27,9 @@ The following steps will guide you on how to run this script.
 2. Replace `main` in `ref=main` with the latest version from the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases).
 3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
 4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
-5. Add the organizational unit ids into the `organizational_unit_ids` param if you don't wish to assign the role to all sub accounts.
-6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
-7. `drata_aws_account_arn` shouldn't be set because the role needs the Drata Account ARN to work as appropriate.
+5. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
+6. If you don't wish to assign the role to all sub accounts, add the organizational unit ids to `organizational_unit_ids`.
+7. `drata_aws_account_arn` shouldn't be set because unless there is a specific requirement.
 8. Back in your terminal, run terraform init to download/update the module.
 9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
 10. If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AWS Cloudformation terraform script to create the Drata Autopilot role across an
 
 The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases) for a list of published versions.
 
-Replace `YOUR_EXTERNAL_ID` with the external id given by the UI. i.e. `00000000-0000-0000-0000-000000000000`.
+Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `00000000-0000-0000-0000-000000000000`.
 Replace `YOUR_MANAGEMENT_ACCOUNT_ID` with the AWS management account. i.e. `012345678912`.
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module "drata_role_cloudformation_stacksets" {
     role_sts_externalid = "YOUR_EXTERNAL_ID"
     # stackset_region = "REGION" # Uncomment if you'd like to change the default value of 'us-west-2'
     # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # Uncomment if you'd like to change the default behavior, which assigns the role to all sub accounts within the organization
-    # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend of running this script is different
+    # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # Uncomment if you'd like to change the default value. The default value should be sufficient for most use cases
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following steps will guide you on how to run this script.
 7. Back in your terminal, run terraform init to download/update the module.
 8. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
 9.  If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
-10. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+10. If you want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # aws-cloudformation-drata-setup
 
-AWS Cloudformation terraform to create the Drata Autopilot role across a given Organization.
+AWS Cloudformation terraform script to create the Drata Autopilot role across an Organizational Unit.
 
 ## Example Usage
 
-The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the release page for a list of published versions. [releases page](https://github.com/drata/gcp-terraform-drata-setup/releases) for a list of published versions.
+The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the release page for a list of published versions. 
+* [CloudFormation repo](https://github.com/drata/aws-cloudformation-drata-setup/releases).
+* [Single account repo](https://github.com/drata/terraform-aws-drata-autopilot-role/releases).
 
-Replace `YOUR_EXTERNAL_ID` with the external id that is given by the UI. i.e. `00000000-0000-0000-0000-000000000000`.
-Replace `YOUR_MANAGEMENT_ACCOUNT_ID` with the id of the management account. i.e. `012345678912`.
+Replace `YOUR_EXTERNAL_ID` with the external id given by the UI. i.e. `00000000-0000-0000-0000-000000000000`.
+Replace `YOUR_MANAGEMENT_ACCOUNT_ID` with the AWS management account. i.e. `012345678912`.
 
 ```
-module "drata_role_stacksets" {
+module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
     drata_external_id = "YOUR_EXTERNAL_ID"
     management_account_id = "YOUR_MANAGEMENT_ACCOUNT_ID"
@@ -19,7 +21,7 @@ module "drata_role_stacksets" {
     # mgmt_account_release_tag = "1.0.0" # If it's unset the default value is 'main'
 }
 
-# as stacksets doesn't create resources in the management account, another module is used to go forward
+# as stacksets isn't able to create resources under the management account, another module is used to go forward
 module "management_account_autopilot_role" {
     source = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=main"
     role_sts_externalid = "YOUR_EXTERNAL_ID"
@@ -32,20 +34,19 @@ module "management_account_autopilot_role" {
 
 The following steps will guide you on how to run this script.
 
-1. Add the code above to your terraform code
-2. Replace `main` in `ref=main` with the latest version from the releases pages.
-   1. [Cloudformation repo](https://github.com/drata/aws-cloudformation-drata-setup/releases).
-   2. [Management account repo](https://github.com/drata/terraform-aws-drata-autopilot-role/releases).
+1. Add the code above to your terraform code.
+2. Replace `main` in `ref=main` with the latest version from the release pages.
+   * [CloudFormation repo](https://github.com/drata/aws-cloudformation-drata-setup/releases).
+   * [Single account repo](https://github.com/drata/terraform-aws-drata-autopilot-role/releases).
 3. In your browser, open https://app.drata.com/account-settings/connections/aws-org-units.
-4. Copy the Drata External ID from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
+4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
 5. Go to the AWS console, get the `Management Account Id` and replace `YOUR_MANAGEMENT_ACCOUNT_ID`.
-6. Replace `stackset_region` if the desired region is different than `us-west-2`.
+6. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
 7. The role name can be customized by setting the `drata_role_name` variable. Recommend to use `DrataAutopilotRole`.
-8. `mgmt_account_release_tag` belongs to the module that creates the role in the management account, so you can point to a specific release version with this. Recommend to use `main`. 
-9. Back in your terminal, run terraform init to download/update the module.
-10. Run terraform apply and IMPORTANT review the plan output before typing yes.
-11. If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
-12. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
+8. Back in your terminal, run terraform init to download/update the module.
+9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
+10. If successful, go back to the AWS console and verify the Role has been generated in all the accounts.
+11. If you'd want to roll back the operations this script just performed, type `terraform destroy` and `enter`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following steps will guide you on how to run this script.
 
 ## Disclaimer
 
-AWS CloudFormation StackSets isn't able to create resources under the management account. If you wish to create the `DrataAutopilotRole` in the management account go to this [repo](https://github.com/drata/terraform-aws-drata-autopilot-role).
+AWS CloudFormation StackSets isn't able to create resources under the management account. If you wish to create the `DrataAutopilotRole` in the management account you can use this [repo](https://github.com/drata/terraform-aws-drata-autopilot-role) or create it manually following our [help documentation](https://help.drata.com/en/articles/5048935-aws-connection-details#h_caf5c48b5d).
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # aws-cloudformation-drata-setup
 
 AWS Cloudformation terraform script to create the Drata Autopilot role across an Organizational Unit.
+***NOTE:*** Make sure you run this script with the management account credentials.
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ module "drata_role_cloudformation_stacksets" {
     source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
     role_sts_externalid = "YOUR_EXTERNAL_ID"
     # stackset_region = "REGION" # Uncomment if you'd like to change the default value of 'us-west-2'
-    # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # If it's unset, the role will be assigned to all sub accounts
+    # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # Uncomment if you'd like to change the default behavior, which assigns the role to all sub accounts within the organization
     # drata_aws_account_arn = "arn:aws:iam::XXXXXXXXXXXX:root" # This shouldn't be set unless the intend of running this script is different
 }
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | Drata External ID from the Drata UI. | `string` | `null` | no |
+| <a name="input_drata_aws_account_arn"></a> [drata\_aws\_account\_arn](#input\_drata\_aws\_account\_arn) | Drata's AWS account ARN | `string` | `"arn:aws:iam::269135526815:root"` | no |
+| <a name="input_organizational_unit_ids"></a> [organizational\_unit\_ids](#input\_organizational\_unit\_ids) | Organizational Unit Ids to assign the role to. | `list(string)` | `null` | no |
+| <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | Drata External ID from the Drata UI. | `string` | n/a | yes |
 | <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |
 
 ## Outputs

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -51,7 +51,7 @@
               "RoleName": {
                   "Ref": "DrataRoleName"
               },
-              "RoleDescription": "Cross-account read-only access for Drata Autopilot"
+              "Description": "Cross-account read-only access for Drata Autopilot"
           }
       }
   }

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -3,10 +3,10 @@
   "Parameters": {
       "RolePrincipalAWS": {
           "Type": "String",
-          "Description": "Management Account ID for this Organization",
-          "Default": "012345678912",
-          "AllowedPattern": "^\\d{12}$",
-          "ConstraintDescription": "ManagementAccountID must be 12 in length and contain numeric characters"
+          "Description": "Management Account ARN for this Organization",
+          "Default": "arn:aws:iam::012345678912:root",
+          "AllowedPattern": "^arn:aws:iam::\\d{12}:root$",
+          "ConstraintDescription": "RolePrincipalAWS must match arn:aws:iam::{ID}:root where ID is a numeric string with length of 12"
       },
       "RoleSTSExternalID": {
           "Type": "String",

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,19 +1,20 @@
 {
   "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
   "Parameters": {
-      "RolePrincipalAWS": {
+      "DrataAWSAccountARN": {
           "Type": "String",
-          "Description": "Management Account Id for this Organization",
-          "Default": "012345678912",
-          "AllowedPattern": "\\d{12}$",
-          "ConstraintDescription": "RolePrincipalAWS a numeric string with length of 12"
+          "Description": "Drata's AWS account ARN.",
+          "Default":"arn:aws:iam::269135526815:root",
+          "AllowedPattern": "arn:aws:iam::\\d{12}:root$",
+          "MinLength": 1,
+          "ConstraintDescription": "DrataAWSAccountARN follows the format 'arn:aws:iam::' followed by exactly 12 digits (numeric characters) and ending with ':root'. It's required."
       },
       "RoleSTSExternalID": {
           "Type": "String",
-          "Description": "STS ExternalId condition value to use with the role",
-          "Default": "00000000-0000-0000-0000-000000000000",
+          "Description": "STS ExternalId condition value to use with the role.",
           "AllowedPattern": "[a-zA-Z0-9\\=\\,\\.\\@\\:\\/\\-_]*",
-          "ConstraintDescription": "STS ExternalId condition value to use with the role must contain alphanumeric characters and only these special characters are allowed =,.@:/-. "
+          "MinLength": 1,
+          "ConstraintDescription": "RoleSTSExternalID must be an UUID formatted string and is required."
       }
   },
   "Resources": {
@@ -28,7 +29,7 @@
                       {
                           "Effect": "Allow",
                           "Principal": {
-                              "AWS": [{ "Ref": "RolePrincipalAWS" }]
+                              "AWS": [{ "Ref": "DrataAWSAccountARN" }]
                           },
                           "Action": "sts:AssumeRole",
                           "Condition": {

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,12 +1,6 @@
 {
   "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
   "Parameters": {
-      "DrataRoleName": {
-          "Type": "String",
-          "Description": "Provide a role name (Example: DrataAutopilotRole)",
-          "AllowedPattern": "[-_a-zA-Z0-9]*[org|Org|ORG][-_a-zA-Z0-9]*",
-          "Default": "DrataAutopilotRole"
-      },
       "ManagementAccountID": {
           "Type": "String",
           "Description": "Management Account ID for this Organization (Example: 012345678912)",
@@ -48,9 +42,7 @@
                       }
                   ]
               },
-              "RoleName": {
-                  "Ref": "DrataRoleName"
-              },
+              "RoleName": "DrataAutopilotRole",
               "Description": "Cross-account read-only access for Drata Autopilot"
           }
       }

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,13 +1,13 @@
 {
   "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
   "Parameters": {
-      "DrataAWSAccountARN": {
+      "DrataAWSAccountID": {
           "Type": "String",
-          "Description": "Drata's AWS account ARN.",
-          "Default":"arn:aws:iam::269135526815:root",
-          "AllowedPattern": "arn:aws:iam::\\d{12}:root$",
+          "Description": "Drata's AWS account ID.",
+          "Default": "269135526815",
+          "AllowedPattern": "\\d{12}$",
           "MinLength": 1,
-          "ConstraintDescription": "DrataAWSAccountARN follows the format 'arn:aws:iam::' followed by exactly 12 digits (numeric characters) and ending with ':root'. It's required."
+          "ConstraintDescription": "DrataAWSAccountID should be exactly 12 digits (numeric characters). It's required."
       },
       "RoleSTSExternalID": {
           "Type": "String",
@@ -29,7 +29,7 @@
                       {
                           "Effect": "Allow",
                           "Principal": {
-                              "AWS": [{ "Ref": "DrataAWSAccountARN" }]
+                              "AWS": [ { "Fn::Sub": "arn:aws:iam::${DrataAWSAccountID}:root" } ]
                           },
                           "Action": "sts:AssumeRole",
                           "Condition": {

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -3,10 +3,10 @@
   "Parameters": {
       "RolePrincipalAWS": {
           "Type": "String",
-          "Description": "Management Account ARN for this Organization",
-          "Default": "arn:aws:iam::012345678912:root",
-          "AllowedPattern": "^arn:aws:iam::\\d{12}:root$",
-          "ConstraintDescription": "RolePrincipalAWS must match arn:aws:iam::{ID}:root where ID is a numeric string with length of 12"
+          "Description": "Management Account Id for this Organization",
+          "Default": "012345678912",
+          "AllowedPattern": "\\d{12}$",
+          "ConstraintDescription": "RolePrincipalAWS a numeric string with length of 12"
       },
       "RoleSTSExternalID": {
           "Type": "String",

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,20 +1,19 @@
 {
   "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
   "Parameters": {
-      "ManagementAccountID": {
+      "RolePrincipalAWS": {
           "Type": "String",
-          "Description": "Management Account ID for this Organization (Example: 012345678912)",
-          "MinLength": "12",
-          "MaxLength": "12",
+          "Description": "Management Account ID for this Organization",
+          "Default": "012345678912",
           "AllowedPattern": "^\\d{12}$",
           "ConstraintDescription": "ManagementAccountID must be 12 in length and contain numeric characters"
       },
-      "ExternalID": {
+      "RoleSTSExternalID": {
           "Type": "String",
-          "Description": "Provide an ExternalID (Example: Xoih821ddwf)",
-          "MinLength": "1",
+          "Description": "STS ExternalId condition value to use with the role",
+          "Default": "00000000-0000-0000-0000-000000000000",
           "AllowedPattern": "[a-zA-Z0-9\\=\\,\\.\\@\\:\\/\\-_]*",
-          "ConstraintDescription": "ExternalID must contain alphanumeric characters and only these special characters are allowed =,.@:/-. "
+          "ConstraintDescription": "STS ExternalId condition value to use with the role must contain alphanumeric characters and only these special characters are allowed =,.@:/-. "
       }
   },
   "Resources": {
@@ -29,13 +28,13 @@
                       {
                           "Effect": "Allow",
                           "Principal": {
-                              "AWS": [{ "Ref": "ManagementAccountID" }]
+                              "AWS": [{ "Ref": "RolePrincipalAWS" }]
                           },
                           "Action": "sts:AssumeRole",
                           "Condition": {
                               "StringEquals": {
                                   "sts:ExternalId": {
-                                      "Ref": "ExternalID"
+                                      "Ref": "RoleSTSExternalID"
                                   }
                               }
                           }

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,0 +1,59 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
+  "Parameters": {
+      "DrataRoleName": {
+          "Type": "String",
+          "Description": "Provide a role name (Example: DrataReadOnlyRole)",
+          "AllowedPattern": "[-_a-zA-Z0-9]*[org|Org|ORG][-_a-zA-Z0-9]*",
+          "Default": "DrataReadOnlyRole"
+      },
+      "ExternalID": {
+          "Type": "String",
+          "Description": "Provide an ExternalID (Example: Xoih821ddwf)",
+          "MinLength": "1",
+          "AllowedPattern": "[a-zA-Z0-9\\=\\,\\.\\@\\:\\/\\-_]*",
+          "ConstraintDescription": "ExternalID must contain alphanumeric characters and only these special characters are allowed =,.@:/-. "
+      }
+  },
+  "Resources": {
+      "DrataRole": {
+          "Type": "AWS::IAM::Role",
+          "Properties": {
+              "ManagedPolicyArns": ["arn:aws:iam::aws:policy/SecurityAudit"],
+              "MaxSessionDuration": 43200,
+              "AssumeRolePolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                      {
+                          "Effect": "Allow",
+                          "Principal": {
+                              "AWS": "arn:aws:iam::xxxxxxxxx:root"
+                          },
+                          "Action": "sts:AssumeRole",
+                          "Condition": {
+                              "StringEquals": {
+                                  "sts:ExternalId": {
+                                      "Ref": "ExternalID"
+                                  }
+                              }
+                          }
+                      }
+                  ]
+              },
+              "RoleName": {
+                  "Ref": "DrataRoleName"
+              },
+              "RoleDescription": "Cross-account read-only access for Drata Autopilot"
+          }
+      }
+  },
+  "Outputs": {
+      "DrataARN": {
+          "Value": {
+              "Fn::GetAtt": ["DrataRole", "Arn"]
+          },
+          "Description": "Role ARN to configure within Drata Account Setup"
+      }
+  }
+}

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,12 +1,20 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
+  "AWSTemplateFormatVersion": "2024-04-15",
   "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
   "Parameters": {
       "DrataRoleName": {
           "Type": "String",
-          "Description": "Provide a role name (Example: DrataReadOnlyRole)",
+          "Description": "Provide a role name (Example: DrataAutopilotRole)",
           "AllowedPattern": "[-_a-zA-Z0-9]*[org|Org|ORG][-_a-zA-Z0-9]*",
-          "Default": "DrataReadOnlyRole"
+          "Default": "DrataAutopilotRole"
+      },
+      "ManagementAccountID": {
+          "Type": "String",
+          "Description": "Management Account ID for this Organization (Example: 012345678912)",
+          "MinLength": "12",
+          "MaxLength": "12",
+          "AllowedPattern": "^\\d{12}$",
+          "ConstraintDescription": "ManagementAccountID must be 12 in length and contain numeric characters"
       },
       "ExternalID": {
           "Type": "String",
@@ -28,7 +36,7 @@
                       {
                           "Effect": "Allow",
                           "Principal": {
-                              "AWS": "arn:aws:iam::xxxxxxxxx:root"
+                              "AWS": [{ "Ref": "ManagementAccountID" }]
                           },
                           "Action": "sts:AssumeRole",
                           "Condition": {
@@ -46,14 +54,6 @@
               },
               "RoleDescription": "Cross-account read-only access for Drata Autopilot"
           }
-      }
-  },
-  "Outputs": {
-      "DrataARN": {
-          "Value": {
-              "Fn::GetAtt": ["DrataRole", "Arn"]
-          },
-          "Description": "Role ARN to configure within Drata Account Setup"
       }
   }
 }

--- a/drata_cloudformation_stackset_template.json
+++ b/drata_cloudformation_stackset_template.json
@@ -1,5 +1,4 @@
 {
-  "AWSTemplateFormatVersion": "2024-04-15",
   "Description": "Drata IAM Role to set read permissions in Org Member Accounts",
   "Parameters": {
       "DrataRoleName": {

--- a/main.tf
+++ b/main.tf
@@ -30,3 +30,11 @@ resource "aws_cloudformation_stack_set_instance" "instances" {
   region         = var.stackset_region
   stack_set_name = aws_cloudformation_stack_set.stack_set.name
 }
+
+# as stacksets doesn't create resources in the management account, another module is used to go forward
+module "drata_management_autopilot_role" {
+  source                = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=main"
+  role_sts_externalid   = var.drata_external_id
+  role_name             = var.role_name
+  drata_aws_account_arn = "arn:aws:iam::${var.management_account_id}:root"
+}

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id, DrataRoleName : var.role_name }
+  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id, DrataRoleName : var.drata_role_name }
 }
 
 # retrive the organization
@@ -33,7 +33,7 @@ resource "aws_cloudformation_stack_set_instance" "instances" {
 
 # as stacksets doesn't create resources in the management account, another module is used to go forward
 module "drata_management_autopilot_role" {
-  source                = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=${var.release_tag}"
+  source                = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=${var.mgmt_account_release_tag}"
   role_sts_externalid   = var.drata_external_id
   role_name             = var.role_name
   drata_aws_account_arn = "arn:aws:iam::${var.management_account_id}:root"

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { ManagementAccountID : local.management_account_id, ExternalID : var.drata_external_id }
+  parameters    = { RolePrincipalAWS : local.management_account_id, RoleSTSExternalID : var.role_sts_externalid }
 }
 
 # apply the stack set to the entire organization using the root id

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 data "aws_organizations_organization" "organization" {}
 
 locals {
-  json_template           = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  json_template           = file(".terraform/modules/drata_role_cloudformation_stacksets/drata_cloudformation_stackset_template.json")
   organizational_unit_ids = var.organizational_unit_ids == null ? [data.aws_organizations_organization.organization.roots[0].id] : var.organizational_unit_ids
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@
 data "aws_organizations_organization" "organization" {}
 
 locals {
-  json_template         = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
-  management_account_id = data.aws_organizations_organization.organization.master_account_id
+  json_template          = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  management_account_arn = data.aws_organizations_organization.organization.master_account_arn
 }
 
 # define the stack set
@@ -20,7 +20,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { RolePrincipalAWS : local.management_account_id, RoleSTSExternalID : var.role_sts_externalid }
+  parameters    = { RolePrincipalAWS : local.management_account_arn, RoleSTSExternalID : var.role_sts_externalid }
 }
 
 # apply the stack set to the entire organization using the root id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  json_template = file("drata_cloudformation_stackset_template.json")
+  json_template = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
 }
 
 # define the stack set

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,29 @@
+# define the stack set
+# this contains the role creation template
+resource "aws_cloudformation_stack_set" "stack_set" {
+  name             = "drata-role-terraform-stack-set"
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_NAMED_IAM"]
+  auto_deployment {
+    enabled = true
+  }
+  operation_preferences {
+    failure_tolerance_count = 0
+    max_concurrent_count    = 3
+  }
+  template_body = jsonencode(
+    file("./drata_cloudformation_stackset_template.json")
+  )
+}
+
+# retrive the organization
+data "aws_organizations_organization" "organization" {}
+
+# apply the stack set to the entire organization using the root id
+resource "aws_cloudformation_stack_set_instance" "instances" {
+  deployment_targets {
+    organizational_unit_ids = [data.aws_organizations_organization.organization.roots[0].id]
+  }
+  region         = var.stackset_region
+  stack_set_name = aws_cloudformation_stack_set.stack_set.name
+}

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { DrataAWSAccountARN : var.drata_aws_account_arn, RoleSTSExternalID : var.role_sts_externalid }
+  parameters    = { DrataAWSAccountID : var.drata_aws_account_id, RoleSTSExternalID : var.role_sts_externalid }
 }
 
 # apply the stack set to the entire organization using the root id

--- a/main.tf
+++ b/main.tf
@@ -30,11 +30,3 @@ resource "aws_cloudformation_stack_set_instance" "instances" {
   region         = var.stackset_region
   stack_set_name = aws_cloudformation_stack_set.stack_set.name
 }
-
-# as stacksets doesn't create resources in the management account, another module is used to go forward
-module "drata_management_autopilot_role" {
-  source                = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=${var.mgmt_account_release_tag}"
-  role_sts_externalid   = var.drata_external_id
-  role_name             = var.role_name
-  drata_aws_account_arn = "arn:aws:iam::${var.management_account_id}:root"
-}

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
 # apply the stack set to the entire organization using the root id
 resource "aws_cloudformation_stack_set_instance" "instances" {
   deployment_targets {
-    organizational_unit_ids = locals.organizational_unit_ids
+    organizational_unit_ids = local.organizational_unit_ids
   }
   region         = var.stackset_region
   stack_set_name = aws_cloudformation_stack_set.stack_set.name

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id, DrataRoleName : var.drata_role_name }
+  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id }
 }
 
 # retrive the organization

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@
 data "aws_organizations_organization" "organization" {}
 
 locals {
-  json_template          = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
-  management_account_arn = data.aws_organizations_organization.organization.master_account_arn
+  json_template         = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  management_account_id = data.aws_organizations_organization.organization.master_account_id
 }
 
 # define the stack set
@@ -20,7 +20,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { RolePrincipalAWS : local.management_account_arn, RoleSTSExternalID : var.role_sts_externalid }
+  parameters    = { RolePrincipalAWS : local.management_account_id, RoleSTSExternalID : var.role_sts_externalid }
 }
 
 # apply the stack set to the entire organization using the root id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
+# get the organization info
+data "aws_organizations_organization" "organization" {}
+
 locals {
-  json_template = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  json_template         = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  management_account_id = data.aws_organizations_organization.organization.master_account_id
 }
 
 # define the stack set
@@ -16,11 +20,8 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id }
+  parameters    = { ManagementAccountID : local.management_account_id, ExternalID : var.drata_external_id }
 }
-
-# retrive the organization
-data "aws_organizations_organization" "organization" {}
 
 # apply the stack set to the entire organization using the root id
 resource "aws_cloudformation_stack_set_instance" "instances" {

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_cloudformation_stack_set_instance" "instances" {
 
 # as stacksets doesn't create resources in the management account, another module is used to go forward
 module "drata_management_autopilot_role" {
-  source                = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=main"
+  source                = "git::https://github.com/drata/terraform-aws-drata-autopilot-role.git?ref=${var.release_tag}"
   role_sts_externalid   = var.drata_external_id
   role_name             = var.role_name
   drata_aws_account_arn = "arn:aws:iam::${var.management_account_id}:root"

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id }
+  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id, DrataRoleName : var.role_name }
 }
 
 # retrive the organization

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = jsonencode(
-    file("./drata_cloudformation_stackset_template.json")
+    file("drata_cloudformation_stackset_template.json")
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,7 @@
 data "aws_organizations_organization" "organization" {}
 
 locals {
-  json_template         = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
-  management_account_id = data.aws_organizations_organization.organization.master_account_id
+  json_template = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
 }
 
 # define the stack set
@@ -20,7 +19,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
-  parameters    = { RolePrincipalAWS : local.management_account_id, RoleSTSExternalID : var.role_sts_externalid }
+  parameters    = { DrataAWSAccountARN : var.drata_aws_account_arn, RoleSTSExternalID : var.role_sts_externalid }
 }
 
 # apply the stack set to the entire organization using the root id

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  json_template = jsonencode(file("drata_cloudformation_stackset_template.json"))
+}
+
 # define the stack set
 # this contains the role creation template
 resource "aws_cloudformation_stack_set" "stack_set" {
@@ -11,9 +15,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     failure_tolerance_count = 0
     max_concurrent_count    = 3
   }
-  template_body = jsonencode(
-    file("drata_cloudformation_stackset_template.json")
-  )
+  template_body = local.json_template
 }
 
 # retrive the organization

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  json_template = jsonencode(file("drata_cloudformation_stackset_template.json"))
+  json_template = file("drata_cloudformation_stackset_template.json")
 }
 
 # define the stack set
@@ -16,6 +16,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
     max_concurrent_count    = 3
   }
   template_body = local.json_template
+  parameters    = { ManagementAccountID : var.management_account_id, ExternalID : var.drata_external_id }
 }
 
 # retrive the organization

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,8 @@
 data "aws_organizations_organization" "organization" {}
 
 locals {
-  json_template = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  json_template           = file(".terraform/modules/drata_role_stacksets/drata_cloudformation_stackset_template.json")
+  organizational_unit_ids = var.organizational_unit_ids == null ? [data.aws_organizations_organization.organization.roots[0].id] : var.organizational_unit_ids
 }
 
 # define the stack set
@@ -25,7 +26,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
 # apply the stack set to the entire organization using the root id
 resource "aws_cloudformation_stack_set_instance" "instances" {
   deployment_targets {
-    organizational_unit_ids = [data.aws_organizations_organization.organization.roots[0].id]
+    organizational_unit_ids = locals.organizational_unit_ids
   }
   region         = var.stackset_region
   stack_set_name = aws_cloudformation_stack_set.stack_set.name

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "stackset_region" {
+  type        = string
+  default     = "us-west-2"
+  description = "Region where the stackset instance will be executed."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,9 @@ variable "role_sts_externalid" {
   type        = string
   description = "Drata External ID from the Drata UI."
 }
+
+variable "organizational_unit_ids" {
+  type        = list(string)
+  default     = null
+  description = "Organizational Unit Ids to assign the role to."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,8 @@ variable "stackset_region" {
   description = "Region where the stackset instance will be executed."
 }
 
-variable "drata_external_id" {
+variable "role_sts_externalid" {
   type        = string
+  default     = null
   description = "Drata External ID from the Drata UI."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,9 +19,3 @@ variable "drata_role_name" {
   description = "Drata role name."
   default     = "DrataAutopilotRole"
 }
-
-variable "mgmt_account_release_tag" {
-  type        = string
-  description = "Release tag utilized to target the terraform module that creates the role in the management account."
-  default     = "main"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "drata_external_id" {
   type        = string
   description = "Retrieved ID from the Drata UI."
 }
+
+variable "role_name" {
+  type        = string
+  description = "Drata role name."
+  default     = "DrataAutopilotRole"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,10 +4,10 @@ variable "stackset_region" {
   description = "Region where the stackset instance will be executed."
 }
 
-variable "drata_aws_account_arn" {
+variable "drata_aws_account_id" {
   type        = string
-  default     = "arn:aws:iam::269135526815:root"
-  description = "Drata's AWS account ARN"
+  default     = "269135526815"
+  description = "Drata's AWS account ID"
 }
 
 variable "role_sts_externalid" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,6 @@ variable "stackset_region" {
   description = "Region where the stackset instance will be executed."
 }
 
-variable "management_account_id" {
-  type        = string
-  description = "Management account id from your organization."
-}
-
 variable "drata_external_id" {
   type        = string
   description = "Drata External ID from the Drata UI."

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,13 @@ variable "stackset_region" {
   description = "Region where the stackset instance will be executed."
 }
 
+variable "drata_aws_account_arn" {
+  type        = string
+  default     = "arn:aws:iam::269135526815:root"
+  description = "Drata's AWS account ARN"
+}
+
 variable "role_sts_externalid" {
   type        = string
-  default     = null
   description = "Drata External ID from the Drata UI."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,13 @@ variable "stackset_region" {
   default     = "us-west-2"
   description = "Region where the stackset instance will be executed."
 }
+
+variable "management_account_id" {
+  type        = string
+  description = "Management account id from your organization."
+}
+
+variable "drata_external_id" {
+  type        = string
+  description = "Retrieved ID from the Drata UI."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,9 @@ variable "role_name" {
   description = "Drata role name."
   default     = "DrataAutopilotRole"
 }
+
+variable "release_tag" {
+  type        = string
+  description = "Release tag utilized to target the terraform module that creates the role in the management account."
+  default     = "main"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,9 +13,3 @@ variable "drata_external_id" {
   type        = string
   description = "Retrieved ID from the Drata UI."
 }
-
-variable "drata_role_name" {
-  type        = string
-  description = "Drata role name."
-  default     = "DrataAutopilotRole"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -14,13 +14,13 @@ variable "drata_external_id" {
   description = "Retrieved ID from the Drata UI."
 }
 
-variable "role_name" {
+variable "drata_role_name" {
   type        = string
   description = "Drata role name."
   default     = "DrataAutopilotRole"
 }
 
-variable "release_tag" {
+variable "mgmt_account_release_tag" {
   type        = string
   description = "Release tag utilized to target the terraform module that creates the role in the management account."
   default     = "main"

--- a/variables.tf
+++ b/variables.tf
@@ -11,5 +11,5 @@ variable "management_account_id" {
 
 variable "drata_external_id" {
   type        = string
-  description = "Retrieved ID from the Drata UI."
+  description = "Drata External ID from the Drata UI."
 }


### PR DESCRIPTION
**Quick note:** If you run this script will get this error `"Resource of type 'AWS::IAM::Role' with identifier 'DrataAutopilotRole' already exists."`. This because the role already exists in our test organization. Change the role name in this [line](https://github.com/drata/aws-cloudformation-drata-setup/pull/1/files#diff-989f07d77f1e756e66761726f4a39081d0e76578000cced1023972dff9c0aa5dR45) (in your downloaded module) to run successfully.

README should look like this =>

# aws-cloudformation-drata-setup

AWS Cloudformation terraform script to create the Drata Autopilot role across an Organizational Unit.
***NOTE:*** Make sure you run this script with the management account credentials. 

_Optionally you may create the CloudFormation StackSet directly in the console, download the [json template](https://github.com/drata/aws-cloudformation-drata-setup/drata_cloudformation_stackset_template.json) and upload it as a template resource._

## Example Usage

The example below uses `ref=main` (which is appended in the URL),  but it is recommended to use a specific tag version (i.e. `ref=1.0.0`) to avoid breaking changes. Go to the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases) for a list of published versions.

Replace `YOUR_EXTERNAL_ID` with the external id provided in the Drata UI. i.e. `00000000-0000-0000-0000-000000000000`.

```
module "drata_role_cloudformation_stacksets" {
    source = "git::https://github.com/drata/aws-cloudformation-drata-setup.git?ref=main"
    role_sts_externalid = "YOUR_EXTERNAL_ID"
    # stackset_region = "REGION" # Uncomment if you'd like to change the default value of 'us-west-2'
    # organizational_unit_ids = ["ORG_ID_1", "ORG_ID_2"] # Uncomment if you'd like to change the default behavior, which assigns the role to all sub accounts within the organization
    # drata_aws_account_id = "XXXXXXXXXXXX" # Uncomment if you'd like to change the default value. The default value should be sufficient for most use cases
}
```

## Setup

The following steps will guide you on how to run this script.

1. Add the code above to your terraform code.
2. Replace `main` in `ref=main` with the latest version from the [release page](https://github.com/drata/aws-cloudformation-drata-setup/releases).
3. In your browser, open [https://app.drata.com/account-settings/connections/connection?provId=AWS_ORG_UNITS](https://app.drata.com/account-settings/connections/connection?provId=AWS_ORG_UNITS&provTypeSelected=Infrastructure&activeTab=browse&q=aws%20org&page=1).
4. Copy the `Drata External ID` from the AWS Org Units connection panel in Drata and replace `YOUR_EXTERNAL_ID` in the module with the ID you copied.
5. Replace `stackset_region` if the desired region is different than the default value `us-west-2`.
6. If you don't wish to assign the role to all sub accounts, add the organizational unit ids to `organizational_unit_ids`.
7. `drata_aws_account_id` shouldn't be set because the default value is enough for most use cases.
8. Back in your terminal, run terraform init to download/update the module.
9. Run terraform apply and **IMPORTANT** review the plan output before typing yes.
10. If successful, go back to the AWS console and verify the Role has been generated in all the sub accounts.
11. If you want to roll back the operations this script just performed, type `terraform destroy` and `enter`.

## Disclaimer

AWS CloudFormation StackSets isn't able to create resources under the management account. If you wish to create the `DrataAutopilotRole` in the management account you can use this [repo](https://github.com/drata/terraform-aws-drata-autopilot-role) or create it manually following our [help documentation](https://help.drata.com/en/articles/5048935-aws-connection-details#h_caf5c48b5d).

<!-- BEGIN_TF_DOCS -->
## Requirements

No requirements.

## Providers

| Name | Version |
|------|---------|
| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |

## Modules

No modules.

## Resources

| Name | Type |
|------|------|
| [aws_cloudformation_stack_set.stack_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
| [aws_cloudformation_stack_set_instance.instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
| [aws_organizations_organization.organization](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |

## Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| <a name="input_drata_aws_account_id"></a> [drata\_aws\_account\_id](#input\_drata\_aws\_account\_id) | Drata's AWS account ID | `string` | `"269135526815"` | no |
| <a name="input_organizational_unit_ids"></a> [organizational\_unit\_ids](#input\_organizational\_unit\_ids) | Organizational Unit Ids to assign the role to. | `list(string)` | `null` | no |
| <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | Drata External ID from the Drata UI. | `string` | n/a | yes |
| <a name="input_stackset_region"></a> [stackset\_region](#input\_stackset\_region) | Region where the stackset instance will be executed. | `string` | `"us-west-2"` | no |

## Outputs

No outputs.
<!-- END_TF_DOCS -->