### PR TITLE
Ignore changes to administration_role_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,10 @@ resource "aws_cloudformation_stack_set" "stack_set" {
   }
   template_body = local.json_template
   parameters    = { DrataAWSAccountID : var.drata_aws_account_id, RoleSTSExternalID : var.role_sts_externalid }
+
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
 }
 
 # apply the stack set to the entire organization using the root id


### PR DESCRIPTION
Ignore changes to `administration_role_arn`, otherwise there is a perpetual diff.

There is a [known issue](https://github.com/hashicorp/terraform-provider-aws/issues/23464) about this happening while using the `SERVICE_MANAGED` permission_model